### PR TITLE
feat: streaming parser to minimize memory footprint

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -1,5 +1,6 @@
 use std::{
-    io::Error,
+    error,
+    io::{BufRead, Error},
     path::{Path, PathBuf},
 };
 
@@ -10,7 +11,7 @@ use crate::parse::{
     profile::{declaration_summary, parse_profile},
 };
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+type Result<T> = std::result::Result<T, Box<dyn error::Error + Send + Sync>>;
 
 pub(crate) struct InsertRecord {
     org: String,
@@ -173,11 +174,14 @@ async fn insert_declarations(
             .map(|s| s.to_string_lossy().replace("__", "."))
             .unwrap_or_default();
 
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let Ok(file) = std::fs::File::open(&path) else {
             continue;
         };
+        let lines = std::io::BufReader::new(file)
+            .lines()
+            .map_while(std::result::Result::ok);
 
-        let report = parse_profile(&path.to_string_lossy(), &content);
+        let report = parse_profile(&path.to_string_lossy(), lines);
         for decl in declaration_summary(&report) {
             sqlx::query(
                 "INSERT INTO declarations (run_id, module, declaration, category, elapsed_secs)

--- a/server/src/parse/profile.rs
+++ b/server/src/parse/profile.rs
@@ -170,14 +170,14 @@ fn parse_line(line: &str) -> Option<ProfileEntry> {
 /// Top-level entries are those with no leading indentation (depth 0).
 /// When full hierarchical parsing is desired in the future, the `children`
 /// field can be populated by tracking the depth stack.
-pub fn parse_profile(source_file: &str, content: &str) -> ProfileReport {
+pub fn parse_profile(source_file: &str, content: impl Iterator<Item = String>) -> ProfileReport {
     let mut declarations: Vec<ProfileEntry> = Vec::new();
     // Stack for building the hierarchy: (depth, entry_index_in_parent_children or declarations)
     // For now we collect flat, but structure supports hierarchy.
     let mut stack: Vec<(usize, ProfileEntry)> = Vec::new();
 
-    for line in content.lines() {
-        let Some(entry) = parse_line(line) else {
+    for line in content {
+        let Some(entry) = parse_line(&line) else {
             // Continuation line: append to the most recent entry's description
             let trimmed = line.trim();
             if !trimmed.is_empty()
@@ -322,7 +322,7 @@ mod tests {
 [Elab.async] [0.096688] elaborating proof of bar
   [Elab.definition.value] [0.095357] bar
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         assert_eq!(report.declarations.len(), 2);
         assert_eq!(report.declarations[0].elapsed_secs, 0.027186);
         assert_eq!(report.declarations[1].elapsed_secs, 0.096688);
@@ -342,7 +342,7 @@ mod tests {
       simp [spec_ok]
     [Elab.step] [0.001000] done
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let top_level = &report.declarations[0];
         assert_eq!(top_level.children.len(), 2);
         assert_eq!(top_level.children[1].children.len(), 2);
@@ -357,7 +357,7 @@ mod tests {
           unfold some.long.name
           simp [spec_ok]
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let elab_step = &report.declarations[0].children[0].children[0];
         assert_eq!(elab_step.category, "Elab.step");
         assert!(matches!(
@@ -374,7 +374,7 @@ mod tests {
 [Elab.async] [0.050000] elaborating /-- Doc. -/\n    theorem schnorr_complete : T
   [Elab.definition.value] [0.049000] schnorr_complete
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let desc = &report.declarations[0].description;
         assert!(
             matches!(desc, ProfileDescription::DeclHeader(h) if h.keyword == "theorem"),
@@ -387,7 +387,7 @@ mod tests {
     fn test_simple_description_stays_simple() {
         // Descriptions that are not valid Lean declarations remain Simple.
         let content = "[Elab.async] [0.010000] running linters\n";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         assert!(matches!(
             &report.declarations[0].description,
             ProfileDescription::Simple(s) if s == "running linters"
@@ -400,7 +400,7 @@ mod tests {
 [Elab.async] [0.027186] elaborating def myFun : T
   [Elab.definition.value] [0.026738] myFun
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let summary = declaration_summary(&report);
         assert_eq!(summary.len(), 1);
         assert_eq!(summary[0].declaration, "myFun");
@@ -412,7 +412,7 @@ mod tests {
         let content = "\
 [Elab.async] [0.027186] running linters
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let summary = declaration_summary(&report);
         assert_eq!(summary.len(), 1);
         assert_eq!(summary[0].declaration, "running linters");
@@ -424,7 +424,7 @@ mod tests {
         let content = "\
 [Elab.async] [0.027186] elaborating proof of foo.bar.baz
 ";
-        let report = parse_profile("test.profile", content);
+        let report = parse_profile("test.profile", content.lines().map(String::from));
         let summary = declaration_summary(&report);
         assert_eq!(summary.len(), 1);
         assert_eq!(summary[0].declaration, "foo.bar.baz");


### PR DESCRIPTION
This PR makes a minor, but very consequential fix. The profile parser was already operating line
by line, so instead of reading the whole file to memory we just iterate over the lines.

This makes a big difference for the Curve25519Dalek benchmark artifacts, where `FunsExternal.lean`
yields a 2.3 gigabyte profile.

Local benchmarks show the reduction (using time -v):
before: `Maximum resident set size (kbytes): 2685960`
after: `Maximum resident set size (kbytes): 508440`
