### PR TITLE
fix: Clean up old extracted files

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -106,7 +106,21 @@ async fn main() {
             }),
         )
         .layer(SetRequestIdLayer::x_request_id(Id))
-        .with_state(storage);
+        .with_state(Arc::clone(&storage));
+
+    // Spawn periodic cleanup of temporary extraction directories (every 6 hours)
+    tokio::spawn({
+        async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 60 * 60));
+            interval.tick().await; // skip immediate first tick
+            loop {
+                interval.tick().await;
+                if let Err(e) = storage.clean_temp_dirs().await {
+                    tracing::error!("Temp directory cleanup failed: {e}");
+                }
+            }
+        }
+    });
 
     tracing::info!(%addr, "Listening");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -20,12 +20,8 @@ pub struct Storage {
 impl Storage {
     pub fn new(base_dir: impl Into<PathBuf>, pool: Pool<Sqlite>) -> Self {
         let base_dir = base_dir.into();
-        std::fs::create_dir_all(base_dir.join("tmp"))
-            .expect("Failed to create tmp directory");
-        Self {
-            db: pool,
-            base_dir,
-        }
+        std::fs::create_dir_all(base_dir.join("tmp")).expect("Failed to create tmp directory");
+        Self { db: pool, base_dir }
     }
 
     pub(crate) fn pool(&self) -> &Pool<Sqlite> {
@@ -109,7 +105,7 @@ impl Storage {
         &self,
         artifact_path: &Path,
     ) -> std::io::Result<tempfile::TempDir> {
-        let tmp = tempfile::tempdir_in(&self.base_dir.join("tmp"))?;
+        let tmp = tempfile::tempdir_in(self.base_dir.join("tmp"))?;
 
         let file = std::fs::File::open(artifact_path)?;
         let gz = flate2::read::GzDecoder::new(file);

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -19,9 +19,12 @@ pub struct Storage {
 
 impl Storage {
     pub fn new(base_dir: impl Into<PathBuf>, pool: Pool<Sqlite>) -> Self {
+        let base_dir = base_dir.into();
+        std::fs::create_dir_all(base_dir.join("tmp"))
+            .expect("Failed to create tmp directory");
         Self {
             db: pool,
-            base_dir: base_dir.into(),
+            base_dir,
         }
     }
 
@@ -106,7 +109,7 @@ impl Storage {
         &self,
         artifact_path: &Path,
     ) -> std::io::Result<tempfile::TempDir> {
-        let tmp = tempfile::tempdir()?;
+        let tmp = tempfile::tempdir_in(&self.base_dir.join("tmp"))?;
 
         let file = std::fs::File::open(artifact_path)?;
         let gz = flate2::read::GzDecoder::new(file);
@@ -115,5 +118,32 @@ impl Storage {
         archive.unpack(tmp.path())?;
 
         Ok(tmp)
+    }
+
+    pub async fn clean_temp_dirs(&self) -> std::io::Result<()> {
+        let tmp_dir = self.base_dir.join("tmp");
+        if !tmp_dir.exists() {
+            return Ok(());
+        }
+
+        let one_hour_ago = std::time::SystemTime::now() - std::time::Duration::from_secs(60 * 60);
+        let mut removed = 0u64;
+        for entry in std::fs::read_dir(&tmp_dir)?.flatten() {
+            let modified = entry.metadata()?.modified()?;
+            if modified >= one_hour_ago {
+                continue;
+            }
+
+            let path = entry.path();
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)?;
+            } else {
+                std::fs::remove_file(&path)?;
+            }
+            removed += 1;
+        }
+
+        tracing::info!(removed, "Cleaned temporary directories older than 1 hour");
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR adds the logic to clean out the extraction directory.

In previous versions of the server, if for whatever reason the server crashed in the middle of 
analysis or extraction the orphaned uncompressed artifacts were left on disk. This PR adds logic to
clean them up to avoid unnecessary data usage.
