### PR TITLE
feat: Improve `get_trace_file` endpoint performance

### DIFF
--- a/scripts/extract_trace_events.py
+++ b/scripts/extract_trace_events.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""One-shot migration: extract lakeprof.trace_event from existing .tar.gz archives.
+
+Usage:
+    python3 extract_trace_events.py /path/to/storage/base_dir
+"""
+
+import sys
+import tarfile
+from pathlib import Path
+
+
+def extract_trace_event(archive: Path, index: int, total: int) -> None:
+    prefix = f"[{index}/{total}]"
+    dest = archive.with_suffix("").with_suffix(".trace_event")
+    if dest.exists():
+        print(f"  {prefix} skipped (already exists): {dest}")
+        return
+
+    try:
+        with tarfile.open(archive, "r:gz") as tar:
+            member = tar.getmember("bench_results/lakeprof.trace_event")
+            with tar.extractfile(member) as f:
+                dest.write_bytes(f.read())
+        print(f"  {prefix} extracted: {dest}")
+    except KeyError:
+        print(f"  {prefix} skipped (no trace_event): {archive}")
+    except Exception as e:
+        print(f"  {prefix} error: {archive}: {e}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <storage_base_dir>")
+        sys.exit(1)
+
+    base = Path(sys.argv[1])
+    if not base.is_dir():
+        print(f"Error: {base} is not a directory")
+        sys.exit(1)
+
+    archives = sorted(base.rglob("*.tar.gz"))
+    print(f"Found {len(archives)} archives")
+
+    for i, archive in enumerate(archives, 1):
+        extract_trace_event(archive, i, len(archives))
+
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -54,11 +54,14 @@ pub(crate) async fn insert_rows(record: InsertRecord, pool: &sqlx::SqlitePool) -
 
     // Extract the archive to a temp dir
     let temp_dir = tempfile::tempdir()?;
-    let file = std::fs::File::open(archive_path)?;
+    let file = std::fs::File::open(&archive_path)?;
     let gz = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(gz);
     archive.unpack(temp_dir.path())?;
     let bench_results = temp_dir.path().join("bench_results");
+
+    // Extract the trace_event file alongside the archive for direct serving.
+    extract_trace_event(&archive_path, &bench_results)?;
 
     let build_times = insert_build_times(&mut tx, run_id, &bench_results).await?;
     let longest_pole = insert_longest_pole(&mut tx, run_id, &bench_results).await?;
@@ -98,6 +101,20 @@ async fn insert_run(
     .await?;
 
     Ok(run_id)
+}
+
+/// Copy `lakeprof.trace_event` next to the archive as `{run_number}.trace_event`.
+fn extract_trace_event(archive_path: &Path, bench_results: &Path) -> Result<()> {
+    let trace_src = bench_results.join("lakeprof.trace_event");
+    if !trace_src.exists() {
+        tracing::warn!("No lakeprof.trace_event found in archive");
+        return Ok(());
+    }
+
+    let trace_dest = crate::utils::trace_event_path(archive_path);
+    std::fs::copy(&trace_src, &trace_dest)?;
+    tracing::info!(?trace_dest, "Extracted trace_event file");
+    Ok(())
 }
 
 /// Parse lakeprof.log and insert file build times. Returns total_build_secs.
@@ -203,6 +220,7 @@ async fn insert_declarations(
 #[derive(sqlx::FromRow)]
 pub(crate) struct RunReport {
     pub id: u32,
+    pub artifact_path: String,
     pub total_build_secs: f64,
     pub total_longest_pole_secs: f64,
 }
@@ -214,7 +232,7 @@ pub(crate) async fn get_latest_run(
     commit: &str,
 ) -> Result<Option<RunReport>> {
     let run_id = sqlx::query_as::<_, RunReport>(
-        "SELECT id, total_build_secs, total_longest_pole_secs
+        "SELECT id, artifact_path, total_build_secs, total_longest_pole_secs
         FROM runs
         where org = ? AND repo = ? AND commit_sha = ?
         ORDER BY run_number DESC

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,3 +3,4 @@ pub mod parse;
 pub(crate) mod report;
 pub mod routes;
 pub mod storage;
+pub(crate) mod utils;

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -250,28 +250,18 @@ pub async fn get_trace_file(
     State(storage): State<AppState>,
     Path((org, repo, commit)): Path<(String, String, String)>,
 ) -> Result<Response, (StatusCode, String)> {
-    let repo_name = format!("{org}/{repo}");
-    let artifact_path = storage.latest_artifact(&repo_name, &commit).ok_or((
-        StatusCode::NOT_FOUND,
-        format!("No artifacts found for {repo_name}/{commit}"),
-    ))?;
+    let run = db::get_latest_run(storage.pool(), &org, &repo, &commit)
+        .await
+        .map_err(db_error)?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            format!("No runs found for {org}/{repo}/{commit}"),
+        ))?;
 
-    let tmp_dir = storage.extract_artifact(&artifact_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to extract: {e}"),
-        )
-    })?;
+    let trace_path = crate::utils::trace_event_path(&run.artifact_path);
 
-    let bench_results = tmp_dir.path().join("bench_results");
-    let trace_event_file = bench_results.join("lakeprof.trace_event");
-
-    let bytes = std::fs::read(&trace_event_file).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to read trace file: {e}"),
-        )
-    })?;
+    let bytes = std::fs::read(&trace_path)
+        .map_err(|e| (StatusCode::NOT_FOUND, format!("Trace file not found: {e}")))?;
 
     Response::builder()
         .header(header::CONTENT_TYPE, "application/json")

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -1,10 +1,6 @@
-use std::{
-    io::Error,
-    path::{Path, PathBuf},
-};
+use std::{io::Error, path::PathBuf};
 
 use sqlx::{Pool, Sqlite};
-use tracing::instrument;
 
 use crate::db::{self, InsertRecord};
 
@@ -78,42 +74,6 @@ impl Storage {
             .map_err(Error::other)?;
 
         Ok(file_path)
-    }
-
-    /// Get the path to the latest artifact for a repo + commit, if any.
-    pub(crate) fn latest_artifact(&self, repo: &str, commit: &str) -> Option<PathBuf> {
-        let dir = self.commit_dir(repo, commit);
-        std::fs::read_dir(&dir)
-            .ok()?
-            .flatten()
-            .filter_map(|e| {
-                let n = e
-                    .file_name()
-                    .to_string_lossy()
-                    .strip_suffix(".tar.gz")?
-                    .parse::<u32>()
-                    .ok()?;
-                Some((n, e.path()))
-            })
-            .max_by_key(|(n, _)| *n)
-            .map(|(_, path)| path)
-    }
-
-    /// Extract a tar.gz artifact to a temporary directory and return the path.
-    #[instrument(skip_all)]
-    pub(crate) fn extract_artifact(
-        &self,
-        artifact_path: &Path,
-    ) -> std::io::Result<tempfile::TempDir> {
-        let tmp = tempfile::tempdir_in(self.base_dir.join("tmp"))?;
-
-        let file = std::fs::File::open(artifact_path)?;
-        let gz = flate2::read::GzDecoder::new(file);
-        let mut archive = tar::Archive::new(gz);
-        tracing::info!("Unpacking archive");
-        archive.unpack(tmp.path())?;
-
-        Ok(tmp)
     }
 
     pub async fn clean_temp_dirs(&self) -> std::io::Result<()> {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,0 +1,30 @@
+use std::path::{Path, PathBuf};
+
+/// Derive the `.trace_event` path from a `.tar.gz` archive path.
+///
+/// `1.tar.gz` → `1.trace_event`
+pub(crate) fn trace_event_path(archive_path: impl AsRef<Path>) -> PathBuf {
+    let p = archive_path.as_ref();
+    let stem = p
+        .file_stem()
+        .and_then(|s| Path::new(s).file_stem())
+        .unwrap_or_default();
+    p.with_file_name(stem).with_extension("trace_event")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trace_event_path_simple() {
+        let result = trace_event_path("1.tar.gz");
+        assert_eq!(result, PathBuf::from("1.trace_event"));
+    }
+
+    #[test]
+    fn test_trace_event_path_with_directory() {
+        let result = trace_event_path("/data/org/repo/abc123/3.tar.gz");
+        assert_eq!(result, PathBuf::from("/data/org/repo/abc123/3.trace_event"));
+    }
+}


### PR DESCRIPTION
The current implementation of the server has to extract and unzip a whole archive in order to serve the `trace_event` file in the `get_trace_file` endpoint. This can take time, and is a costly operation.

This PR changes the endpoint to look for the `trace_event` files uncompressed next to the compressed archives.

The trade-off is that the `trace_event` files are stored uncompressed next to the compressed archives. They are generally pretty small (~30kb for a medium to large project), so we view the trade-off as worth it.

This PR also provides a migration script to extract the `trace_event` files in case the running server was brought up before this architectural change.